### PR TITLE
While skipping rows, BitFieldReader tries to load the next values w/o ch...

### DIFF
--- a/hive-dwrf/src/main/java/com/facebook/hive/orc/BitFieldReader.java
+++ b/hive-dwrf/src/main/java/com/facebook/hive/orc/BitFieldReader.java
@@ -97,8 +97,16 @@ public class BitFieldReader {
     } else {
       totalBits -= bitsLeft;
       input.skip(totalBits / 8);
-      current = input.next();
       bitsLeft = (int) (8 - (totalBits % 8));
+
+      // Load the next value only if the stream still has data. If not,
+      // then mark bitsLeft as zero to force exception when values are
+      // attempted to be read.
+      if (input.hasNext()) {
+        current = input.next();
+      } else {
+        bitsLeft = 0;
+      }
     }
   }
 

--- a/hive-dwrf/src/test/java/com/facebook/hive/orc/OrcTestUtils.java
+++ b/hive-dwrf/src/test/java/com/facebook/hive/orc/OrcTestUtils.java
@@ -203,4 +203,14 @@ public class OrcTestUtils {
     }
     return result;
   }
+
+  public static class StringListWithId {
+    Integer id;
+    List<String> list = new ArrayList<String>();
+
+    public StringListWithId(Integer id, List<String> l1) {
+      this.id = id;
+      this.list = l1;
+    }
+  }
 }


### PR DESCRIPTION
...ecking if the stream has ended.
