### PR TITLE
seekToRow in RecordReaderImpl does not update rowInStripe which can caus...

### DIFF
--- a/hive-dwrf/src/main/java/com/facebook/hive/orc/RecordReaderImpl.java
+++ b/hive-dwrf/src/main/java/com/facebook/hive/orc/RecordReaderImpl.java
@@ -491,11 +491,17 @@ class RecordReaderImpl implements RecordReader {
 
   @Override
   public void seekToRow(long rowNumber) throws IOException {
+    // Update the stripe
     int rightStripe = findStripe(rowNumber);
     if (rightStripe != currentStripe) {
       currentStripe = rightStripe;
       readStripe();
     }
+
+    // Update the row number within the stripe
+    rowInStripe = rowNumber - rowBaseInStripe;
+
+    // Update the reader
     reader.seekToRow(rowNumber);
   }
 

--- a/hive-dwrf/src/test/java/com/facebook/hive/orc/MemoryManagerWithForce.java
+++ b/hive-dwrf/src/test/java/com/facebook/hive/orc/MemoryManagerWithForce.java
@@ -1,0 +1,31 @@
+package com.facebook.hive.orc;
+
+import org.apache.hadoop.conf.Configuration;
+
+import java.io.IOException;
+
+/**
+ *
+ * MemoryManagerWithForce.
+ *
+ * An implementation of MemoryManager with the ability to force writers to flush their stripes
+ * and to enter low memory mode.
+ */
+public class MemoryManagerWithForce extends MemoryManager {
+
+  MemoryManagerWithForce(Configuration conf) {
+    super(conf);
+  }
+
+  public void forceFlushStripe() throws IOException {
+    for (WriterInfo writer : writerList.values()) {
+      writer.callback.checkMemory(0);
+    }
+  }
+
+  public void forceEnterLowMemoryMode() throws IOException {
+    for (WriterInfo writer : writerList.values()) {
+      writer.callback.enterLowMemoryMode();
+    }
+  }
+}


### PR DESCRIPTION
...e readers to read off the end of streams because a new stripe may not be read when the end of the stripe is reached.

Added a test case to demonstrate this.

Also, modified another test case to call seekToRow to skip <n> rows instead of calling seekToRow for each row regardless of whether the row is read or not.

Tests pass.
